### PR TITLE
Segment labels and redirections

### DIFF
--- a/docs/portainer.yml
+++ b/docs/portainer.yml
@@ -35,11 +35,8 @@ services:
         - traefik.port=9000
         - traefik.tags=traefik-public
         - traefik.docker.network=traefik-public
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
 
 networks:
   agent-network:

--- a/docs/swarmpit.yml
+++ b/docs/swarmpit.yml
@@ -29,11 +29,8 @@ services:
         - traefik.port=8080
         - traefik.tags=traefik-public
         - traefik.docker.network=traefik-public
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
 
   db:
     image: couchdb:2.3.0

--- a/docs/thelounge.yml
+++ b/docs/thelounge.yml
@@ -17,11 +17,8 @@ services:
         - traefik.port=9000
         - traefik.tags=traefik-public
         - traefik.docker.network=traefik-public
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
 
 networks:
   traefik-public:

--- a/docs/traefik-host.yml
+++ b/docs/traefik-host.yml
@@ -19,11 +19,8 @@ services:
         - traefik.port=8500
         - traefik.tags=${TRAEFIK_PUBLIC_TAG:-traefik-public}
         - traefik.docker.network=traefik-public
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
         - traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}
   consul-replica:
     image: consul
@@ -63,11 +60,8 @@ services:
         - traefik.port=8080
         - traefik.tags=traefik-public
         - traefik.docker.network=traefik-public
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
         - traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docs/traefik-technical-details.md
+++ b/docs/traefik-technical-details.md
@@ -29,7 +29,7 @@ It has several deployment labels, these are what make Traefik expose the Consul 
 * `traefik.port=8500`: expose the content from the port `8500` (that's the port inside the container).
 * `traefik.tags=${TRAEFIK_PUBLIC_TAG:-traefik-public}`: as the main Traefik proxy will only expose services with the `traefik-public` tag (using a parameter below), make the Consul service have this tag too, so that the Traefik public can find it and expose it. Use as the tag the environment variable `TRAEFIK_PUBLIC_TAG`, or by default, set it to `traefik-public`.
 * `traefik.docker.network=traefik-public`: tell Traefik to get the contents provided by this service using that shared network.
-* `traefik.frontend.entryPoints=https`: make the web UI listen and serve on HTTP and HTTPS.
+* `traefik.frontend.entryPoints=http,https`: make the web UI listen and serve on HTTP and HTTPS.
 * `traefik.frontend.redirect.entryPoint=https`: make Traefik redirect HTTP trafic to HTTPS for the web UI.
 * `traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}`: enable basic auth, so that not everyone can access your Traefik web dashboard, it uses the username and password created above. If those environment variables are not set, show the error "`Variable USERNAME not set`" or "`Variable HASHED_PASSWORD not set`".
 

--- a/docs/traefik-technical-details.md
+++ b/docs/traefik-technical-details.md
@@ -29,9 +29,8 @@ It has several deployment labels, these are what make Traefik expose the Consul 
 * `traefik.port=8500`: expose the content from the port `8500` (that's the port inside the container).
 * `traefik.tags=${TRAEFIK_PUBLIC_TAG:-traefik-public}`: as the main Traefik proxy will only expose services with the `traefik-public` tag (using a parameter below), make the Consul service have this tag too, so that the Traefik public can find it and expose it. Use as the tag the environment variable `TRAEFIK_PUBLIC_TAG`, or by default, set it to `traefik-public`.
 * `traefik.docker.network=traefik-public`: tell Traefik to get the contents provided by this service using that shared network.
-* `traefik.redirectorservice.frontend.entryPoints=http`: make the service listen to HTTP, so that it can redirect to HTTPS.
-* `traefik.redirectorservice.frontend.redirect.entryPoint=https`: make Traefik redirect HTTP trafic to HTTPS for the web UI.
-* `traefik.webservice.frontend.entryPoints=https`: make the web UI listen and serve on HTTPS.
+* `traefik.frontend.entryPoints=https`: make the web UI listen and serve on HTTP and HTTPS.
+* `traefik.frontend.redirect.entryPoint=https`: make Traefik redirect HTTP trafic to HTTPS for the web UI.
 * `traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}`: enable basic auth, so that not everyone can access your Traefik web dashboard, it uses the username and password created above. If those environment variables are not set, show the error "`Variable USERNAME not set`" or "`Variable HASHED_PASSWORD not set`".
 
 ```YAML hl_lines="4 6 10 11 13 14 17 18 19 20 21 22 23 24 25 26 27"

--- a/docs/traefik-with-volume.md
+++ b/docs/traefik-with-volume.md
@@ -108,9 +108,8 @@ docker service create \
     --label "traefik.port=8080" \
     --label "traefik.tags=traefik-public" \
     --label "traefik.docker.network=traefik-public" \
-    --label "traefik.redirectorservice.frontend.entryPoints=http" \
-    --label "traefik.redirectorservice.frontend.redirect.entryPoint=https" \
-    --label "traefik.webservice.frontend.entryPoints=https" \
+    --label "traefik.frontend.entryPoints=http,https" \
+    --label "traefik.frontend.redirect.entryPoint=https" \
     --label "traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}" \
     traefik:v1.7 \
     --docker \
@@ -149,9 +148,8 @@ The previous command explained:
 * `--label "traefik.port=8080"`: when Traefik exposes itself as a service (for the dashboard), use the internal service port `8080`
 * `--label "traefik.tags=traefik-public"`: as the main Traefik proxy will only expose services with the `traefik-public` tag (using a parameter below), make the dashboard service have this tag too, so that the Traefik public (itself) can find it and expose it
 * `--label "traefik.docker.network=traefik-public"`: make the dashboard service use the `traefik-public` network to expose itself
-* `--label "traefik.redirectorservice.frontend.entryPoints=http"`: make the web dashboard listen to HTTP, so that it can redirect to HTTPS
-* `--label "traefik.redirectorservice.frontend.redirect.entryPoint=https"`: make Traefik redirect HTTP trafic to HTTPS for the web dashboard
-* `--label "traefik.webservice.frontend.entryPoints=https"`: make the web dashboard listen and serve on HTTPS
+* `--label "traefik.frontend.entryPoints=http"`: make the web dashboard listen and serve on HTTP and HTTPS
+* `--label "traefik.frontend.redirect.entryPoint=https"`: make Traefik redirect HTTP trafic to HTTPS for the web dashboard
 * `--label "traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}"`: enable basic auth, so that not every one can access your Traefik web dashboard, it uses the username and password created above. If the variables are not set, show an error.
 * `traefik:v1.7`: use the image `traefik:v1.7`
 * `--docker`: enable Docker
@@ -222,9 +220,8 @@ docker service create \
     --label "traefik.port=8080" \
     --label "traefik.tags=traefik-public" \
     --label "traefik.docker.network=traefik-public" \
-    --label "traefik.redirectorservice.frontend.entryPoints=http" \
-    --label "traefik.redirectorservice.frontend.redirect.entryPoint=https" \
-    --label "traefik.webservice.frontend.entryPoints=https" \
+    --label "traefik.frontend.entryPoints=http,https" \
+    --label "traefik.frontend.redirect.entryPoint=https" \
     --label "traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}" \
     traefik:v1.7 \
     --docker \

--- a/docs/traefik.yml
+++ b/docs/traefik.yml
@@ -19,11 +19,8 @@ services:
         - traefik.port=8500
         - traefik.tags=${TRAEFIK_PUBLIC_TAG:-traefik-public}
         - traefik.docker.network=traefik-public
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
         - traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}
   consul-replica:
     image: consul
@@ -59,11 +56,8 @@ services:
         - traefik.port=8080
         - traefik.tags=traefik-public
         - traefik.docker.network=traefik-public
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
         - traefik.frontend.auth.basic.users=${USERNAME?Variable USERNAME not set}:${HASHED_PASSWORD?Variable HASHED_PASSWORD not set}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
I recommend to not add a segment to only create a HTTPS redirection.

The segments are mainly made to manage multiple ports on one container.

I created this PR because some our users follow this guide and create segments even if it's not needed.