### PR TITLE
🔧 Update `portainer.yml` to use the new Docker Hub image

### DIFF
--- a/docs/portainer.yml
+++ b/docs/portainer.yml
@@ -17,7 +17,7 @@ services:
           - node.platform.os == linux
 
   portainer:
-    image: portainer/portainer
+    image: portainer/portainer-ce
     command: -H tcp://tasks.agent:9001 --tlsskipverify
     volumes:
       - portainer-data:/data


### PR DESCRIPTION
Update to the latest 2.0 version which now is under portainer-ce.