### PR TITLE
Updated Portainer to 2.5.1

### DIFF
--- a/docs/portainer.yml
+++ b/docs/portainer.yml
@@ -17,7 +17,7 @@ services:
           - node.platform.os == linux
 
   portainer:
-    image: portainer/portainer
+    image: portainer/portainer-ce:2.5.1
     command: -H tcp://tasks.agent:9001 --tlsskipverify
     volumes:
       - portainer-data:/data


### PR DESCRIPTION
Hello!  This is my first pull request to a public repo, so I hope I'm doing this right! 

portainer/portainer is now deprecated according to https://hub.docker.com/r/portainer/portainer.  I tested installing with the configuration in this PR, and it works for me for new installs, and when upgrading from the current configuration.

Thanks for reviewing! 