### PR TITLE
✨ Add Traefik v3 instructions

### DIFF
--- a/docs/traefik-v3.yml
+++ b/docs/traefik-v3.yml
@@ -1,0 +1,98 @@
+version: '3.3'
+
+services:
+
+  traefik:
+    # Use the latest v3.0.x Traefik image available
+    image: traefik:v3.0
+    ports:
+      # Listen on port 80, default for HTTP, necessary to redirect to HTTPS
+      - 80:80
+      # Listen on port 443, default for HTTPS
+      - 443:443
+    deploy:
+      placement:
+        constraints:
+          # Make the traefik service run only on the node with this label
+          # as the node with it has the volume for the certificates
+          - node.labels.traefik-public.traefik-public-certificates == true
+      labels:
+        # Enable Traefik for this service, to make it available in the public network
+        - traefik.enable=true
+        # Use the traefik-public network (declared below)
+        - traefik.docker.network=traefik-public
+        # Use the custom label "traefik.constraint-label=traefik-public"
+        # This public Traefik will only use services with this label
+        # That way you can add other internal Traefik instances per stack if needed
+        - traefik.constraint-label=traefik-public
+        # admin-auth middleware with HTTP Basic auth
+        # Using the environment variables USERNAME and HASHED_PASSWORD
+        - traefik.http.middlewares.admin-auth.basicauth.users=${USERNAME?Variable not set}:${HASHED_PASSWORD?Variable not set}
+        # https-redirect middleware to redirect HTTP to HTTPS
+        # It can be re-used by other stacks in other Docker Compose files
+        - traefik.http.middlewares.https-redirect.redirectscheme.scheme=https
+        - traefik.http.middlewares.https-redirect.redirectscheme.permanent=true
+        # traefik-http set up only to use the middleware to redirect to https
+        # Uses the environment variable DOMAIN
+        - traefik.http.routers.traefik-public-http.rule=Host(`${DOMAIN?Variable not set}`)
+        - traefik.http.routers.traefik-public-http.entrypoints=http
+        - traefik.http.routers.traefik-public-http.middlewares=https-redirect
+        # traefik-https the actual router using HTTPS
+        # Uses the environment variable DOMAIN
+        - traefik.http.routers.traefik-public-https.rule=Host(`${DOMAIN?Variable not set}`)
+        - traefik.http.routers.traefik-public-https.entrypoints=https
+        - traefik.http.routers.traefik-public-https.tls=true
+        # Use the special Traefik service api@internal with the web UI/Dashboard
+        - traefik.http.routers.traefik-public-https.service=api@internal
+        # Use the "le" (Let's Encrypt) resolver created below
+        - traefik.http.routers.traefik-public-https.tls.certresolver=le
+        # Enable HTTP Basic auth, using the middleware created above
+        - traefik.http.routers.traefik-public-https.middlewares=admin-auth
+        # Define the port inside of the Docker service to use
+        - traefik.http.services.traefik-public.loadbalancer.server.port=8080
+    volumes:
+      # Add Docker as a mounted volume, so that Traefik can read the labels of other services
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Mount the volume to store the certificates
+      - traefik-public-certificates:/certificates
+    command:
+      # Enable Docker in Traefik, so that it reads labels from Docker services
+      - --providers.docker
+      # Add a constraint to only use services with the label "traefik.constraint-label=traefik-public"
+      - --providers.docker.constraints=Label(`traefik.constraint-label`, `traefik-public`)
+      # Do not expose all Docker services, only the ones explicitly exposed
+      - --providers.docker.exposedbydefault=false
+      # Enable Docker Swarm mode
+      - --providers.swarm.endpoint=unix:///var/run/docker.sock
+      # Create an entrypoint "http" listening on port 80
+      - --entrypoints.http.address=:80
+      # Create an entrypoint "https" listening on port 443
+      - --entrypoints.https.address=:443
+      # Create the certificate resolver "le" for Let's Encrypt, uses the environment variable EMAIL
+      - --certificatesresolvers.le.acme.email=${EMAIL?Variable not set}
+      # Store the Let's Encrypt certificates in the mounted volume
+      - --certificatesresolvers.le.acme.storage=/certificates/acme.json
+      # Use the TLS Challenge for Let's Encrypt
+      - --certificatesresolvers.le.acme.tlschallenge=true
+      # Enable the access log, with HTTP requests
+      - --accesslog
+      # Enable the Traefik log, for configurations and errors
+      - --log
+      # Enable the Dashboard and API
+      - --api
+    networks:
+      # Use the public network created to be shared between Traefik and
+      # any other service that needs to be publicly available with HTTPS
+      - traefik-public
+
+volumes:
+  # Create a volume to store the certificates, there is a constraint to make sure
+  # Traefik is always deployed to the same Docker node with the same volume containing
+  # the HTTPS certificates
+  traefik-public-certificates:
+
+networks:
+  # Use the previously created public network "traefik-public", shared with other
+  # services that need to be publicly available via this Traefik
+  traefik-public:
+    external: true

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -1,10 +1,11 @@
 # Traefik Proxy with HTTPS
 
-## Note - version 2
+## Note - version 2 (and v3)
 
-This guide is updated for Traefik version 2. ✨
+This guide is updated for Traefik version 2 and version 3. ✨
 
 If you are looking for the previous guides for Traefik version 1, check them in <a href="https://dockerswarm.rocks/traefik-v1/" class="external-link" target="_blank">DockerSwarm.rocks/traefik-v1/</a>.
+Using Traefik 3 is only one line difference in the YAML used to deploy Traefik, and is detailed below.
 
 !!! note
     There are many applications and some project generators based on the previous guides for Traefik version 1.
@@ -116,10 +117,16 @@ $apr1$89eqM5Ro$CxaFELthUKV21DpI3UTQO.
 
 ## Create the Docker Compose file
 
-* Download the file `traefik.yml`:
+* Download the file `traefik.yml` for Traefik v2:
 
 ```bash
 curl -L dockerswarm.rocks/traefik.yml -o traefik.yml
+```
+
+or `traefik-v3.yml` for Traefik 3
+
+```bash
+curl -L dockerswarm.rocks/traefik-v3.yml -o traefik.yml
 ```
 
 * ...or create it manually, for example, using `nano`:
@@ -133,6 +140,17 @@ nano traefik.yml
 ```YAML
 {!./traefik.yml!}
 ```
+
+or for Traefik 3, where the only difference is how the swarm mode is activated:
+
+<details>
+  <summary>traefik-v3.yml</summary>
+
+```YAML
+{!./traefik-v3.yml!}
+```
+
+</details>
 
 !!! tip
     Read the internal comments to learn what each configuration is for.


### PR DESCRIPTION
The only difference is how swarm mode is activated, replacing
```
--providers.docker.swarmmode
```
by
```
--providers.swarm.endpoint=unix:///var/run/docker.sock
```