### PR TITLE
🐛 Fix `cadvisor` image in Swarmprom, use Google Registry

### DIFF
--- a/docs/swarmprom.yml
+++ b/docs/swarmprom.yml
@@ -39,7 +39,7 @@ services:
           memory: 64M
 
   cadvisor:
-    image: google/cadvisor
+    image: gcr.io/cadvisor/cadvisor
     networks:
       - net
     command: -logtostderr -docker_only


### PR DESCRIPTION
Following the Swarmprom tutorial, Cadvisor repeatedly fails to start using the `google/cadvisor` image, however this is easily
fixed by using `gcr.io/cadvisor/cadvisor` instead.

Found the related issue and solution in  [google/cadvisor#1943](https://github.com/google/cadvisor/issues/1943#issuecomment-889822000)