### PR TITLE
📝 Add link to https://dockerswarmstill.rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ See [Docker Swarm Mode or Kubernetes](swarm-or-kubernetes.md) for more informati
 
 If you want to see alternative resources, you could check the [awesome-swarm](https://github.com/BretFisher/awesome-swarm) list for more resources about Docker Swarm Mode. 🤓
 
+Or have a look at [Docker Swarm still rocks](https://dockerswarmstill.rocks) that is a continuation of the work done here. 👍
+
 ## Why?
 
 <a href="https://www.docker.com/" target="_blank">Docker</a> is a great tool (the "de facto" standard) to build **Linux containers**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,8 @@ See [Docker Swarm Mode or Kubernetes](swarm-or-kubernetes.md) for more informati
 
 If you want to see alternative resources, you could check the [awesome-swarm](https://github.com/BretFisher/awesome-swarm) list for more resources about Docker Swarm Mode. 🤓
 
+Or have a look at [Docker Swarm still rocks](https://dockerswarmstill.rocks) that is a continuation of the work done here. 👍
+
 ## Why?
 
 <a href="https://www.docker.com/" target="_blank">Docker</a> is a great tool (the "de facto" standard) to build **Linux containers**.


### PR DESCRIPTION
@tiangolo Your site was very instrumental on setting up my own Swarm cluster. I think, that [Docker Swarm still rocks](https://dockerswarmstill.rocks) and I have adapted the docs to the current eco-system, while actually deploying and running the website itself on Docker Swarm.

I can understand, that you shifted your priorities, but **I** think there is still a use case for Docker Swarm and thus it would be nice, if you could link to the "new" site. :)

As I forked your project, I took the _"ehm"_ liberty of re-using some of the code, that you initially conceived. There was no licence stated, but I "re-imagined" a lot of stuff:
* complete, isolated `docker compose` - based build
* totally new deployment re-using the `docker compose` - based build
* updated guides with new ideas and actually more Docker swarm concepts (configs, local Traefik config, ...)

There are still some artifacts of the old site left, that are going to be replaced in the next weeks. If you want me to remove anything particular or are uncomfortable with, just let me know, by either contacting me directly (use LinkedIn to get my email) or by filing an issue on the new repo or by simply replying here.

Thanks for the effort into building dockerswarm.rocks - let us continue in providing value to the community!