### PR TITLE
👷 Simplify pull request workflow triggers

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    types:
-      - opened
-      - synchronize
 permissions: {}
 jobs:
   changes:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,9 +1,6 @@
 name: pre-commit
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
 permissions: {}
 env:
   # Forks and Dependabot don't have access to secrets


### PR DESCRIPTION
## Summary
- Simplify workflow `pull_request` event declarations by removing explicit `opened` and `synchronize` activity filters.
- Let GitHub use the default `pull_request` activity set, which also includes `reopened`.

## Validation
- Parsed each changed workflow as YAML before and after the edit.
- Checked the resulting diff is limited to the `pull_request` trigger simplification.

## AI Disclaimer
Using Codex with GPT-5.5. Reviewed manually.
