### PR TITLE
🐛 Use buttons for Termynal controls

### DIFF
--- a/docs/css/termynal.css
+++ b/docs/css/termynal.css
@@ -55,10 +55,19 @@
     text-align: center;
 }
 
-a[data-terminal-control] {
+button[data-terminal-control] {
+    cursor: pointer;
     text-align: right;
     display: block;
+    width: 100%;
     color: #aebbff;
+    border: 0;
+    background: transparent;
+    font: inherit;
+}
+
+button[data-terminal-control]:hover {
+    color: var(--color-text);
 }
 
 [data-ty] {

--- a/docs/js/termynal.js
+++ b/docs/js/termynal.js
@@ -127,27 +127,29 @@ class Termynal {
     }
 
     generateRestart() {
-        const restart = document.createElement('a')
-        restart.onclick = (e) => {
-            e.preventDefault()
+        const restart = document.createElement('button')
+        restart.type = 'button'
+
+        restart.onclick = () => {
             this.container.innerHTML = ''
             this.init()
         }
-        restart.href = 'javascript:void(0)'
+
         restart.setAttribute('data-terminal-control', '')
         restart.innerHTML = "restart ↻"
         return restart
     }
 
     generateFinish() {
-        const finish = document.createElement('a')
-        finish.onclick = (e) => {
-            e.preventDefault()
+        const finish = document.createElement('button')
+        finish.type = 'button'
+
+        finish.onclick = () => {
             this.lineDelay = 0
             this.typeDelay = 0
             this.startDelay = 0
         }
-        finish.href = 'javascript:void(0)'
+
         finish.setAttribute('data-terminal-control', '')
         finish.innerHTML = "fast →"
         this.finishElement = finish


### PR DESCRIPTION
## Summary

- render the Termynal `fast` and `restart` controls as semantic buttons
- preserve their terminal styling and add explicit hover feedback
- remove link-only behavior that caused external-link presentation in the docs

This mirrors fastapi/typer#1912. The controls perform actions rather than navigation, so buttons avoid browser and documentation-theme link handling while retaining the existing behavior.

## Checks

- `git diff --check`
- verified the focused diff matches the merged Typer implementation

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.
