### PR TITLE
🐛 Pin label checker action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,7 +27,7 @@ jobs:
       - labeler
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://agilepathway/pull-request-label-checker:latest
+      - uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5 # v1.6.65
         with:
           one_of: breaking,security,feature,bug,refactor,upgrade,docs,lang-all,internal
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- replace the floating Docker image for the pull request label checker with the pinned GitHub Action used by the other managed repositories
- preserve the existing accepted release-note labels

## Motivation

The dependency update in #369 upgrades zizmor to 1.29.0. That version rejects the existing `docker://agilepathway/pull-request-label-checker:latest` reference because the container image is not pinned.

Using the action at its immutable commit resolves the finding and avoids depending on a mutable `latest` image.

## Checks

- `uvx --from zizmor==1.29.0 zizmor .`
- `git diff --check`

## AI Disclaimer

Using Codex with gpt-5.6-sol. Reviewed manually.
